### PR TITLE
fixing license metadata in pyproject.toml and add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+src/cronboard.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "A terminal-based dashboard for managing cron jobs"
 version = "0.3.1"
 readme = "README.md"
-license = "MIT"
+license = { text = "MIT" }
 requires-python = ">=3.13"
 dependencies = [
   "bcrypt>=5.0.0",


### PR DESCRIPTION
👋 To avoid this error when installing via uv

<img width="728" height="450" alt="Capture d’écran_2025-11-10_12-17-18" src="https://github.com/user-attachments/assets/9314f211-2f16-4829-a0f9-7da50a227b23" />
