### PR TITLE
Validate host input in Add Server

### DIFF
--- a/src/test/cronboard_test.py
+++ b/src/test/cronboard_test.py
@@ -1,6 +1,7 @@
 from cronboard.app import CronBoard
 from cronboard_widgets.CronCreator import CronCreator
 from cronboard_widgets.CronDeleteConfirmation import CronDeleteConfirmation
+from cronboard_widgets.CronSSHModal import CronSSHModal
 import pytest
 
 
@@ -46,3 +47,24 @@ async def test_delete_cronjob():
         await pilot.press("tab")
         await pilot.press("D")
         assert isinstance(app.screen, CronDeleteConfirmation)
+
+
+def test_parse_host_info_defaults_port():
+    hostname, port = CronSSHModal._parse_host_info("node9")
+    assert hostname == "node9"
+    assert port == 22
+
+
+def test_parse_host_info_with_port():
+    hostname, port = CronSSHModal._parse_host_info("node9:2222")
+    assert hostname == "node9"
+    assert port == 2222
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", ":", "node9:", ":2222", "node9:abc", "node9:0", "node9:70000"],
+)
+def test_parse_host_info_invalid(value):
+    with pytest.raises(ValueError):
+        CronSSHModal._parse_host_info(value)


### PR DESCRIPTION
Fixes #16

- Root cause: Add Server assumes `host:port` and uses `hostname/port` even after a failed split, which raises `UnboundLocalError` for host-only input.
- Fix: parse host safely, allow `host` or `host:port`, default to port 22, validate port range, and surface specific input errors.
- Tests: `pytest src/test/cronboard_test.py`
