### PR TITLE
fix: handle duplicated id error in cron creator

### DIFF
--- a/src/cronboard_widgets/CronCreator.py
+++ b/src/cronboard_widgets/CronCreator.py
@@ -266,6 +266,10 @@ class CronCreator(ModalScreen[bool]):
         await self.dismiss(False)
 
     def on_input_changed(self, event: Input.Changed) -> None:
+        error_labels = self.query("#error")
+        for label in error_labels:
+            label.remove()
+
         if event.input.id != "expression":
             return
 
@@ -273,13 +277,12 @@ class CronCreator(ModalScreen[bool]):
         expr = event.value.strip()
         self.expression_description(expr, label_desc)
 
-        error_labels = self.query("#error")
-        for label in error_labels:
-            label.remove()
-
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id != "save":
             self.dismiss(False)
+            return
+
+        if self.query("#error"):
             return
 
         identificator_input = self.query_one("#identificator", Input)


### PR DESCRIPTION
## What this changes

Fixes validation behavior in the cron job dialog:

- Clears existing error messages on input change before re-validating.
- Prevents the Save action from proceeding when validation errors are present.
- Ensures the “ID cannot be empty” error does not persist after fields are corrected.
- Avoids the app crash caused by repeatedly clicking Save while errors exist.

## Related Issues

fixes #47 

## How I tested this

- Reproduced the original issue following the reported steps.
- Verified that:
   - Error messages are cleared when inputs change.
   - Filling all required fields removes the validation error.
   - Clicking Save no longer crashes the app.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] A human has reviewed the **entire diff** of this PR, every line of code
- [x] A human understands the changes and can explain why this approach is correct
- [x] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review
