### PR TITLE
feat: make list behavior more intuitive

### DIFF
--- a/src/cronboard/app.py
+++ b/src/cronboard/app.py
@@ -3,9 +3,10 @@ from importlib.metadata import version, PackageNotFoundError
 from crontab import CronTab
 import tomlkit
 from pathlib import Path
+from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.widgets import Footer, Label, Tabs, Tab
+from textual.widgets import Footer, Label, Tabs, Tab, Tree, Button, Input, Checkbox, MaskedInput, RadioButton, Select, Switch, TextArea
 from cronboard_widgets.CronTable import CronTable
 from textual.containers import Container
 from cronboard_widgets.CronTabs import CronTabs
@@ -13,6 +14,8 @@ from cronboard_widgets.CronCreator import CronCreator
 from cronboard_widgets.CronDeleteConfirmation import CronDeleteConfirmation
 from cronboard_widgets.CronServers import CronServers
 
+def is_form_element(element):
+    return isinstance(element, (Input, Checkbox, Button, MaskedInput, RadioButton, Select, Switch, TextArea))
 
 class CronBoard(App):
     """A Textual App to manage cron jobs."""
@@ -22,7 +25,7 @@ class CronBoard(App):
 
     BINDINGS = [
         Binding("q,ctrl+q", "quit", "Quit", priority=True),
-        Binding("Tab", "focus_next", "Change Panel"),
+        Binding("Tab", "next_tab_and_focus", "Change Panel"),
     ]
 
     def compose(self) -> ComposeResult:
@@ -46,6 +49,7 @@ class CronBoard(App):
         self.local_table = CronTable(id="local-crontable")
         self.content_container.mount(self.local_table)
         self.local_table.display = True
+        self.set_focus(self.local_table)
 
     def load_config(self):
         if self.config_path.exists():
@@ -82,6 +86,40 @@ class CronBoard(App):
                 self.content_container.mount(self.servers)
             self.local_table.display = False
             self.servers.display = True
+
+    def on_key(self, event: events.Key) -> None:
+        if event.key != "tab":
+            return
+        
+        if is_form_element(self.focused):
+            return
+
+        event.prevent_default()
+        self.action_next_tab_and_focus()
+
+    def action_next_tab_and_focus(self) -> None:
+        tabs = self.tabs
+        tab_widgets = list(tabs.query(Tab))
+        tab_ids = [tab.id for tab in tab_widgets]
+        current = tabs.active
+        index = tab_ids.index(current)
+
+        next_index = (index + 1) % len(tab_ids)
+        next_tab_id = tab_ids[next_index]
+
+        tabs.active = next_tab_id
+
+        self.show_tab_content(next_index)
+        self._focus_active_panel()
+
+    def _focus_active_panel(self) -> None:
+        if self.tabs.active == "local":
+            if self.local_table:
+                self.set_focus(self.local_table)
+
+        elif self.tabs.active == "servers":
+            if self.servers:
+                self.servers.focus_tree()
 
     def action_create_cronjob(
         self, cron: CronTab, remote=False, ssh_client=None, crontab_user=None

--- a/src/cronboard/app.py
+++ b/src/cronboard/app.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.widgets import Footer, Label, Tabs, Tab, Tree, Button, Input, Checkbox, MaskedInput, RadioButton, Select, Switch, TextArea
+from textual.widgets import Footer, Label, Tabs, Tab, Button, Input, Checkbox, MaskedInput, RadioButton, Select, Switch, TextArea
 from cronboard_widgets.CronTable import CronTable
 from textual.containers import Container
 from cronboard_widgets.CronTabs import CronTabs

--- a/src/cronboard_widgets/CronServers.py
+++ b/src/cronboard_widgets/CronServers.py
@@ -20,6 +20,7 @@ class CronServers(Widget):
         Binding("D", "delete_server", "Delete Server"),
         Binding("c", "connect_server", "Connect"),
         Binding("d", "disconnect_server", "Disconnect Server"),
+        Binding("J", "jump", "Jump"),
     ]
 
     def __init__(self) -> None:
@@ -300,3 +301,21 @@ class CronServers(Widget):
             message=f"Are you sure you want to delete the server '{server_info['name']}' ?",
         )
         self.app.push_screen(confirmation_modal, on_delete_confirmed)
+
+    def focus_tree(self):
+        try:
+            self._focus_tree()
+        except:
+            self.call_after_refresh(self._focus_tree)
+    
+    def _focus_tree(self):
+        tree = self.query_one("#servers-tree", Tree)
+        if tree:
+            tree.focus()
+
+    def action_jump(self) -> None:
+        servers_tree = self.query_one("#servers-tree", Tree)
+        if servers_tree.has_focus and self.current_cron_table:
+            self.current_cron_table.focus()
+        else:
+            servers_tree.focus()

--- a/tests/CronCreator_test.py
+++ b/tests/CronCreator_test.py
@@ -9,7 +9,6 @@ from cronboard_widgets.CronCreator import CronAutoComplete
 @pytest.mark.asyncio
 async def test_open_create_cronjob_modal(app: CronBoard):
     async with app.run_test() as pilot:
-        await pilot.press("tab")
         await pilot.press("c")
         assert isinstance(app.screen, CronCreator)
 

--- a/tests/CronDeleteConfirmation_test.py
+++ b/tests/CronDeleteConfirmation_test.py
@@ -8,7 +8,6 @@ from pytest_mock import MockerFixture
 @pytest.mark.asyncio
 async def test_open_delete_cronjob_modal(app: CronBoard):
     async with app.run_test() as pilot:
-        await pilot.press("tab")
         await pilot.press("D")
         assert isinstance(app.screen, CronDeleteConfirmation)
 
@@ -16,7 +15,6 @@ async def test_open_delete_cronjob_modal(app: CronBoard):
 @pytest.mark.asyncio
 async def test_delete_cronjob_cancel(app: CronBoard):
     async with app.run_test() as pilot:
-        await pilot.press("tab")
         await pilot.press("D")
         await pilot.press("tab")
         await pilot.press("enter")
@@ -26,7 +24,6 @@ async def test_delete_cronjob_cancel(app: CronBoard):
 @pytest.mark.asyncio
 async def test_delete_cronjob_confirm(app: CronBoard):
     async with app.run_test() as pilot:
-        await pilot.press("tab")
         await pilot.press("D")
         await pilot.press("enter")
         assert not isinstance(app.screen, CronDeleteConfirmation)

--- a/tests/CronInputSearch_test.py
+++ b/tests/CronInputSearch_test.py
@@ -4,7 +4,6 @@ from textual.pilot import Pilot
 
 
 async def search_input(pilot: Pilot):
-    await pilot.press("tab")
     await pilot.press("/")
     await pilot.press("c")
     await pilot.press("r")
@@ -15,14 +14,12 @@ async def search_input(pilot: Pilot):
 
 @pytest.mark.asyncio
 async def test_open_search_modal(pilot: Pilot):
-    await pilot.press("tab")
     await pilot.press("/")
     assert isinstance(pilot.app.screen, CronInputSearch)
 
 
 @pytest.mark.asyncio
 async def test_close_search_modal(pilot: Pilot):
-    await pilot.press("tab")
     await pilot.press("/")
     await pilot.press("escape")
     assert not isinstance(pilot.app.screen, CronInputSearch)

--- a/tests/CronServers_test.py
+++ b/tests/CronServers_test.py
@@ -1,3 +1,4 @@
+import pytest
 from cronboard_widgets.CronServers import CronServers
 
 

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -1,13 +1,20 @@
 import pytest
 from cronboard.app import CronBoard
-
+from textual.widgets import Tree
 
 @pytest.mark.asyncio
 async def test_change_tab(app: CronBoard):
     async with app.run_test() as pilot:
-        await pilot.press("tab")
-        assert app.local_table.has_focus
+        assert app.tabs.active == "local"
 
+        await pilot.press("tab")
+        await pilot.pause()
+
+        assert app.tabs.active == "servers"
+        assert app.servers is not None
+
+        server_tree = app.servers.query_one("#servers-tree", Tree)
+        assert server_tree.has_focus
 
 @pytest.mark.asyncio
 async def test_refresh_data(app: CronBoard):


### PR DESCRIPTION
## What this changes

This PR updates the list behavior to make it more intuitive and align it with the idea in issue #36. It improves the user experience by adjusting how the list works so it behaves in a more expected way.

## Related Issues

resolves #36 

## How I tested this

### Tab navigation between sections
- Press Tab to switch focus between:
   - Local tab → Servers tab
   - Servers tab → Local tab
### Servers tab behavior
- Connect to a server in Servers tab
- Verify keyboard navigation:
   - Press J to move focus from the server tree → cron table
   - Press J again to move focus from cron table → server tree
- Press Tab to move focus out of the Servers tab (to Local tab)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] A human has reviewed the **entire diff** of this PR, every line of code
- [x] A human understands the changes and can explain why this approach is correct
- [x] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review
