### PR TITLE
fix: include missing logging scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,4 @@ dev = [
 ]
 
 [tool.setuptools.package-data]
-"cronboard" = ["static/css/*.tcss"]
+"cronboard" = ["static/css/*.tcss", "logging/*.sh"]


### PR DESCRIPTION
## What this changes

when doing brew install crontab it worked, but when trying to save a new cron, or edit a existing one, i got:
```
FileNotFoundError:` [Errno 2] No such file or directory: '/opt/homebrew/Cellar/cronboard/0.7.0/libexec/lib/python3.14/site-packages/cronboard/logging/cron-wrapper.sh'
```

I only tested it on local crons, there the issue happened every time

## How I tested this

running it and pytest successful

hard to say if this really fixes the issue, but its my best guess.
using uv to install it works either way, and i don't know how to test the homebrew way. i guess it would need to be published?

to be honest im not a python expert, but just wish this tool would work out of the box with homebrew for me. Open for your knowledge if including the logging sh files should be enough, or if there even is a way to test this locally. Maybe also there is just something wrong in the homebrew publish process.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] A human has reviewed the **entire diff** of this PR, every line of code
- [ ] A human understands the changes and can explain why this approach is correct
- [x] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review
