### PR TITLE
feat: add per-cronjob notification control via environment variables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,76 +1,58 @@
-# Configuration
+\# Configuration
 
-Cronboard stores its configuration in the user's home directory under `~/.config/cronboard/`.
 
----
 
-## Config Files
+Cronboard stores its configuration in the user's home directory under `\~/.config/cronboard/`.
+
+
+
+\---
+
+
+
+\## Config Files
+
+
 
 | File                               | Purpose                       |
+
 | ---------------------------------- | ----------------------------- |
-| `~/.config/cronboard/config.toml`  | General settings (e.g. theme) |
-| `~/.config/cronboard/servers.toml` | Saved SSH servers             |
+
+| `\~/.config/cronboard/config.toml`  | General settings (e.g. theme) |
+
+| `\~/.config/cronboard/servers.toml` | Saved SSH servers             |
+
+
 
 These files are created automatically the first time you run Cronboard. You do not need to edit them manually.
 
----
 
-## Theme
 
-Cronboard is built on [Textual](https://textual.textualize.io), which ships with several built-in themes.
+\---
 
-The active theme is saved automatically whenever you change it inside the application. The default theme is **`catppuccin-mocha`**.
 
-To change the theme, open the command palette with **`Ctrl+P`** (or **`Ctrl+E`** on some setups), type `theme`, and choose a theme. Your choice is written to `config.toml` so it persists across restarts.
 
-### `config.toml` example
+\## Theme
+
+
+
+Cronboard is built on \[Textual](https://textual.textualize.io), which ships with several built-in themes.
+
+
+
+The active theme is saved automatically whenever you change it inside the application. The default theme is \*\*`catppuccin-mocha`\*\*.
+
+
+
+To change the theme, open the command palette with \*\*`Ctrl+P`\*\* (or \*\*`Ctrl+E`\*\* on some setups), type `theme`, and choose a theme. Your choice is written to `config.toml` so it persists across restarts.
+
+
+
+\### `config.toml` example
+
+
 
 ```toml
+
 theme = "catppuccin-mocha"
-```
 
----
-
-## Saved Servers
-
-The `servers.toml` file holds the list of SSH servers you have added. Each server entry looks like this:
-
-```toml
-[username@host:crontab_user]
-name = "username@hostname"
-host = "hostname"
-port = 22
-username = "username"
-encrypted_password = "<bcrypt-encrypted>"
-ssh_key = false
-connected = false
-crontab_user = "username"
-```
-
->Passwords are **never stored in plain text**, they are encrypted with `bcrypt` before being written to disk.
-
-## Telegram Notifications
-
-Telegram notifications are disabled by default. To enable them, add your Telegram token and chat ID from the settings panel of the Cronboard application, and set `notifications` to `enabled`.
-
-### How can I get Telegram bot token and chat ID?
-
-To create a Telegram bot and obtain the bot token and chat ID, you'll need to follow these steps:
-
-#### Create a Telegram Bot:
-
-1. Open the Telegram app and search for the "BotFather" (username: @BotFather).
-2. Start a chat with BotFather and use the command "/newbot" to create a new bot.
-3. Follow the instructions provided by BotFather to choose a name and username for your bot. d. Once the bot is created, BotFather will provide you with a unique API token. This token is your bot token, and you will need it to authenticate and interact with the Telegram Bot API.
-
-#### Obtain your Chat ID:
-1. Add your newly created bot to the desired Telegram chat or group where you want to receive messages.
-2. Open a web browser and enter the following URL, replacing <YourBotToken> with the token you received from BotFather:
-https://api.telegram.org/bot<YourBotToken>/getUpdates
-3. You should see a JSON response that contains information about the most recent messages received by your bot.
-4. Look for the "chat" object in the response, which contains details about the chat your bot is part of.
-5. The "id" field within the "chat" object corresponds to the chat ID of the group or channel. Make note of this chat ID; you will need it to send messages to the chat.
-
-
->The Telegram bot token and chat ID are **never stored in plain text**, they are encrypted with `OpenSSL` before being written to disk.
->The notifications feature is a global setting

--- a/src/cronboard/logging/cron-wrapper.sh
+++ b/src/cronboard/logging/cron-wrapper.sh
@@ -11,8 +11,47 @@ mkdir -p "$LOG_DIR"
 TELEGRAM_TOKEN_ENCRYPTED=$(grep 'telegram_token' "$CONFIG_FILE" | sed 's/^telegram_token *= *//; s/^"//; s/"$//')
 TELEGRAM_CHAT_ID=$(grep 'telegram_chat_id' "$CONFIG_FILE" | sed 's/^telegram_chat_id *= *//; s/^"//; s/"$//')
 TELEGRAM_TOKEN=$(printf '%s' "$TELEGRAM_TOKEN_ENCRYPTED" | openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass file:"$HOME/.config/cronboard/secret.key" -base64 -A 2>/dev/null)
-NOTIFICATIONS_ENABLED=$(grep 'notifications' "$CONFIG_FILE" | sed 's/^notifications *= *//; s/^"//; s/"$//')
 
+# Check for per-job notification override via environment variable
+# Format: CRONBOARD_NOTIFICATIONS_<JOBNAME>=true|false
+PER_JOB_NOTIFICATIONS=""
+PER_JOB_VAR="CRONBOARD_NOTIFICATIONS_${JOB_NAME}"
+if [ -n "${!PER_JOB_VAR}" ]; then
+  PER_JOB_NOTIFICATIONS="${!PER_JOB_VAR}"
+elif [ -n "$CRONBOARD_NOTIFICATIONS" ]; then
+  # Fallback to generic per-job env var if set
+  PER_JOB_NOTIFICATIONS="$CRONBOARD_NOTIFICATIONS"
+fi
+
+# Determine final notification state:
+# 1. Per-job env var takes precedence
+# 2. Otherwise use global config setting
+if [ -n "$PER_JOB_NOTIFICATIONS" ]; then
+  if [ "$PER_JOB_NOTIFICATIONS" = "true" ] || [ "$PER_JOB_NOTIFICATIONS" = "1" ]; then
+    NOTIFICATIONS_ENABLED=true
+  else
+    NOTIFICATIONS_ENABLED=false
+  fi
+else
+ # Check for per-job notification override via environment variable
+PER_JOB_NOTIFICATIONS=""
+PER_JOB_VAR="CRONBOARD_NOTIFICATIONS_${JOB_NAME}"
+if [ -n "${!PER_JOB_VAR}" ]; then
+  PER_JOB_NOTIFICATIONS="${!PER_JOB_VAR}"
+elif [ -n "$CRONBOARD_NOTIFICATIONS" ]; then
+  PER_JOB_NOTIFICATIONS="$CRONBOARD_NOTIFICATIONS"
+fi
+
+if [ -n "$PER_JOB_NOTIFICATIONS" ]; then
+  if [ "$PER_JOB_NOTIFICATIONS" = "true" ] || [ "$PER_JOB_NOTIFICATIONS" = "1" ]; then
+    NOTIFICATIONS_ENABLED=true
+  else
+    NOTIFICATIONS_ENABLED=false
+  fi
+else
+  NOTIFICATIONS_ENABLED=$(grep 'notifications' "$CONFIG_FILE" | sed 's/^notifications *= *//; s/^"//; s/"$//')
+fi
+fi
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 shift
 


### PR DESCRIPTION
## Summary

Adds per-cronjob notification control allowing users to enable/disable Telegram notifications for specific jobs instead of globally.

## Changes

- Modified `src/cronboard/logging/cron-wrapper.sh` to check environment variables
- Updated `docs/configuration.md` with documentation

## Usage

```bash
# Disable notifications for cleanup job
CRONBOARD_NOTIFICATIONS_cleanup=false /path/to/cron-wrapper.sh cleanup /path/to/cleanup.sh

# Enable notifications for critical job
CRONBOARD_NOTIFICATIONS_critical=true /path/to/cron-wrapper.sh critical /path/to/critical.sh