### PR TITLE
feat(notifications): allow enabling notifications per cronjob

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,4 +73,15 @@ https://api.telegram.org/bot<YourBotToken>/getUpdates
 
 
 >The Telegram bot token and chat ID are **never stored in plain text**, they are encrypted with `OpenSSL` before being written to disk.
->The notifications feature is a global setting
+
+### Notifications per cron job
+
+The settings panel holds the global switch: with it disabled no job notifies. With it enabled, each cron job can still opt out on its own.
+
+The creation/edit form has an **Enable notifications / Disable notifications** option. Choosing *Disable notifications* writes a `--no-notify` flag into the wrapped crontab line of that job, so the setting travels with the job and works the same on local and remote crontabs:
+
+```
+* * * * * /bin/bash ~/.config/cronboard/cron-wrapper.sh backup-job --no-notify cronboard1:<command>
+```
+
+Notifications are sent by the log wrapper, so a job only notifies when **logging is enabled** for it, the global switch is on, and the job is not opted out. Jobs created before this option existed keep following the global setting.

--- a/src/cronboard/logging/cron-wrapper.sh
+++ b/src/cronboard/logging/cron-wrapper.sh
@@ -16,6 +16,14 @@ NOTIFICATIONS_ENABLED=$(grep 'notifications' "$CONFIG_FILE" | sed 's/^notificati
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 shift
 
+# Per-cronjob notification switch. Lines without the flag keep following the
+# global setting, so cronjobs created before this flag existed are unaffected.
+JOB_NOTIFICATIONS_ENABLED=true
+if [ "${1:-}" = "--no-notify" ]; then
+  JOB_NOTIFICATIONS_ENABLED=false
+  shift
+fi
+
 LOG_FILE="$LOG_DIR/${JOB_NAME}_${TIMESTAMP}.log"
 ERR_FILE="$LOG_DIR/${JOB_NAME}_${TIMESTAMP}.err"
 
@@ -106,7 +114,7 @@ fi
 rm -f "$LOG_FILE.out" "$ERR_FILE"
 
 # Send notification
-if [ $EXIT_CODE -ne 0 ] && $NOTIFICATIONS_ENABLED; then
+if [ $EXIT_CODE -ne 0 ] && $NOTIFICATIONS_ENABLED && $JOB_NOTIFICATIONS_ENABLED; then
   if [ -z "$TELEGRAM_TOKEN" ]; then
     echo "ERROR: Telegram token is empty - decryption likely failed" >> "$LOG_FILE"
   else

--- a/src/cronboard/screens/cron_creator.py
+++ b/src/cronboard/screens/cron_creator.py
@@ -12,6 +12,7 @@ from cronboard.services.cron_autocomplete import CronAutoComplete
 from cronboard.services.cron_logging.cron_wrapper import (
     command_without_wrapper,
     has_wrapper,
+    notifications_enabled,
     wrap_command,
 )
 from cronboard.widgets.cron_vim_keys_radio_set import VimKeysRadioSet
@@ -65,6 +66,7 @@ class CronCreator(ModalScreen[bool]):
         self.command: str | None = command
         self.identificator: str | None = identificator
         self.log_enabled: bool = has_wrapper(command) if command else False
+        self.notifications: bool = notifications_enabled(command) if command else True
         self.cron: CronTab = cron
         self.remote: bool = remote
         self.ssh_client: SSHClient | None = ssh_client
@@ -124,6 +126,23 @@ class CronCreator(ModalScreen[bool]):
                         "Disable logging", id="disable", value=not self.log_enabled
                     ),
                 )
+                yield Label(
+                    "Tick if you want to be notified when this job fails "
+                    "(needs logging)",
+                    classes="form-label mt-2 pt-2",
+                )
+                yield VimKeysRadioSet(
+                    RadioButton(
+                        "Enable notifications",
+                        id="enable-notifications",
+                        value=self.notifications,
+                    ),
+                    RadioButton(
+                        "Disable notifications",
+                        id="disable-notifications",
+                        value=not self.notifications,
+                    ),
+                )
                 yield Horizontal(
                     Button("Save", variant="primary", id="save"),
                     Button("Cancel", variant="error", id="cancel"),
@@ -176,7 +195,7 @@ class CronCreator(ModalScreen[bool]):
         self.expression_description(expr, label_desc)
 
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
-        """Enable/disable logs using radio buttons
+        """Enable/disable logs and notifications using radio buttons
 
         Args:
             event: RadioSet.Changed object. Identifies the button throught id.
@@ -186,6 +205,10 @@ class CronCreator(ModalScreen[bool]):
             self.log_enabled = True
         elif event.pressed.id == "disable":
             self.log_enabled = False
+        elif event.pressed.id == "enable-notifications":
+            self.notifications = True
+        elif event.pressed.id == "disable-notifications":
+            self.notifications = False
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Determines the action on button pressed. It saves the cronjob on save. Shows
@@ -235,6 +258,7 @@ class CronCreator(ModalScreen[bool]):
                     command,
                     identificator,
                     self.ssh_client if self.remote and self.ssh_client else None,
+                    self.notifications,
                 )
             if job:
                 job.set_command(command)
@@ -324,6 +348,9 @@ class CronCreator(ModalScreen[bool]):
     def find_if_cronjob_exists(self, identificator: str, cmd: str):
         """Search for a cronjob in the list.
 
+        Commands are also compared without the log wrapper, so a job is still
+        found after its logging or notification setting changed.
+
         Args:
             identificator: String which identifies the cronjob.
             cmd: String representation of the command the cronjob executes.
@@ -333,6 +360,9 @@ class CronCreator(ModalScreen[bool]):
 
         """
         for job in self.cron:
-            if job.comment == identificator and job.command == cmd:
+            if job.comment == identificator and (
+                job.command == cmd
+                or command_without_wrapper(job.command) == command_without_wrapper(cmd)
+            ):
                 return job
         return None

--- a/src/cronboard/services/cron_logging/cron_wrapper.py
+++ b/src/cronboard/services/cron_logging/cron_wrapper.py
@@ -29,6 +29,14 @@ prefix still run via the wrapper's multi-argument branch.
 
 COMMAND_PAYLOAD_PREFIX = "cronboard1:"
 
+"""
+Flag placed before the command payload in wrapped crontab lines when the user
+turned notifications off for that cronjob. Lines without it keep following the
+global notifications setting.
+"""
+
+NO_NOTIFY_FLAG = "--no-notify"
+
 
 def get_remote_bash_path(ssh: paramiko.SSHClient) -> str:
     """Gets the path to the bash executable on the remote server.
@@ -290,6 +298,7 @@ def wrap_command(
     command: str,
     identificator: str,
     ssh: paramiko.SSHClient | None = None,
+    notifications: bool = True,
 ) -> str:
     """Wraps the cronjob's command with the log wrapper.
 
@@ -297,6 +306,7 @@ def wrap_command(
         command: The command to wrap.
         identificator: The identificator of the cronjob.
         ssh: Paramiko SSH client for remote operations.
+        notifications: Whether this cronjob may send notifications when it fails.
 
     Returns:
         The wrapped command if the wrapper is installed, else the original command.
@@ -325,9 +335,10 @@ def wrap_command(
     ):
         return command
     payload: str = _encode_wrapped_command_payload(command)
+    no_notify: str = "" if notifications else f"{NO_NOTIFY_FLAG} "
     return (
         f"{shlex.quote(bash_path)} {shlex.quote(wrapper_path)} "
-        f"{shlex.quote(identificator)} {shlex.quote(payload)}"
+        f"{shlex.quote(identificator)} {no_notify}{shlex.quote(payload)}"
     )
 
 
@@ -384,11 +395,33 @@ def command_without_wrapper(command: str) -> str:
 
     if not wrapper_path.endswith("cron-wrapper.sh"):
         return command
-    if len(parts) < 4:
+
+    rest: list[str] = parts[3:]
+    if rest[0] == NO_NOTIFY_FLAG:
+        rest = rest[1:]
+    if not rest:
         return command
 
-    decoded: str | None = _decode_wrapped_command_payload(parts[3])
+    decoded: str | None = _decode_wrapped_command_payload(rest[0])
     if decoded is not None:
         return decoded
     # Legacy: remainder was split as argv words; best-effort rejoin.
-    return " ".join(parts[3:])
+    return " ".join(rest)
+
+
+def notifications_enabled(command: str) -> bool:
+    """Checks if the cronjob is allowed to send notifications when it fails.
+
+    Args:
+        command: The command to check.
+
+    Returns:
+        False if notifications were turned off for this cronjob, else True.
+    """
+
+    try:
+        parts: list[str] = shlex.split(command)
+    except ValueError:
+        return True
+
+    return len(parts) < 4 or parts[3] != NO_NOTIFY_FLAG

--- a/src/cronboard/widgets/cron_table.py
+++ b/src/cronboard/widgets/cron_table.py
@@ -487,7 +487,10 @@ class CronTable(DataTable):
         }
 
         for job in cron_to_use:
-            if job.comment == identificator and job.command in cmd_variants:
+            if job.comment == identificator and (
+                job.command in cmd_variants
+                or command_without_wrapper(job.command) == command_without_wrapper(cmd)
+            ):
                 return job
         return None
 

--- a/tests/screens/test_cron_creator.py
+++ b/tests/screens/test_cron_creator.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest_mock import MockerFixture
+from textual.widgets import RadioButton
 
 from cronboard.app import CronBoard
 from cronboard.screens.cron_creator import CronAutoComplete, CronCreator
@@ -11,6 +12,21 @@ async def test_open_create_cronjob_modal(app: CronBoard):
     async with app.run_test() as pilot:
         await pilot.press("c")
         assert isinstance(app.screen, CronCreator)
+
+
+@pytest.mark.asyncio
+async def test_notifications_radio_updates_the_modal(app: CronBoard):
+    async with app.run_test() as pilot:
+        await pilot.press("c")
+        screen: CronCreator = app.screen
+
+        assert screen.query_one("#enable-notifications", RadioButton).value is True
+
+        screen.query_one("#disable-notifications", RadioButton).value = True
+        await pilot.pause()
+
+        assert screen.notifications is False
+        assert screen.log_enabled is False
 
 
 def test_returns_job_when_match(mocker: MockerFixture):
@@ -42,6 +58,37 @@ def test_returns_none_when_only_comment_matches(mocker: MockerFixture):
 
     result = creator.find_if_cronjob_exists("backup-job", "/usr/bin/backup.sh")
     assert result is None
+
+
+def test_returns_job_when_only_the_wrapper_differs(mocker: MockerFixture):
+    job = mocker.MagicMock()
+    job.comment = "backup-job"
+    job.command = (
+        "/bin/bash /tmp/cron-wrapper.sh backup-job --no-notify "
+        "cronboard1:ZWNobyBoZWxsbw=="
+    )
+
+    creator = make_creator(mocker)
+    creator.cron.__iter__ = mocker.MagicMock(return_value=iter([job]))
+
+    result = creator.find_if_cronjob_exists("backup-job", "echo hello")
+    assert result == job
+
+
+def test_notifications_enabled_by_default(mocker: MockerFixture):
+    creator = make_creator(mocker)
+    assert creator.notifications is True
+
+
+def test_notifications_disabled_when_command_has_the_flag(mocker: MockerFixture):
+    creator = make_creator(
+        mocker,
+        command=(
+            "/bin/bash /tmp/cron-wrapper.sh backup-job --no-notify "
+            "cronboard1:ZWNobyBoZWxsbw=="
+        ),
+    )
+    assert creator.notifications is False
 
 
 def test_get_search_string_no_slash(

--- a/tests/services/logging_service/cron_wrapper_test.py
+++ b/tests/services/logging_service/cron_wrapper_test.py
@@ -235,6 +235,22 @@ def test_wrap_command_includes_identificator(mock_bash, mock_wrapper_installed):
     assert res == ("/bin/bash /tmp/cron-wrapper.sh job-42 cronboard1:ZWNobyBoZWxsbw==")
 
 
+def test_wrap_command_with_notifications_disabled(mock_bash, mock_wrapper_installed):
+    res = mod.wrap_command("echo hello", "job-1", None, False)
+
+    assert res == (
+        "/bin/bash /tmp/cron-wrapper.sh job-1 --no-notify cronboard1:ZWNobyBoZWxsbw=="
+    )
+
+
+def test_wrap_command_with_notifications_enabled_has_no_flag(
+    mock_bash, mock_wrapper_installed
+):
+    res = mod.wrap_command("echo hello", "job-1", None, True)
+
+    assert mod.NO_NOTIFY_FLAG not in res
+
+
 def test_has_wrapper_valid(mock_bash):
     cmd = "/bin/bash /tmp/cron-wrapper.sh job-1 echo hello"
     assert mod.has_wrapper(cmd) is True
@@ -336,3 +352,48 @@ def test_command_without_wrapper_extra_spaces(mock_bash):
     res = mod.command_without_wrapper(cmd)
 
     assert res == "echo hello"
+
+
+def test_command_without_wrapper_skips_no_notify_flag(mock_bash):
+    cmd = "/bin/bash /tmp/cron-wrapper.sh job-1 --no-notify cronboard1:ZWNobyBoZWxsbw=="
+    res = mod.command_without_wrapper(cmd)
+
+    assert res == "echo hello"
+
+
+def test_command_without_wrapper_no_notify_flag_without_command(mock_bash):
+    cmd = "/bin/bash /tmp/cron-wrapper.sh job-1 --no-notify"
+    res = mod.command_without_wrapper(cmd)
+
+    assert res == cmd
+
+
+def test_wrap_command_without_notifications_round_trip(
+    mock_bash, mock_wrapper_installed
+):
+    inner = "echo 'a' && echo \"b\" | wc -l"
+    wrapped = mod.wrap_command(inner, "job-x", None, False)
+
+    assert mod.command_without_wrapper(wrapped) == inner
+    assert mod.has_wrapper(wrapped) is True
+    assert mod.notifications_enabled(wrapped) is False
+
+
+def test_notifications_enabled_without_flag(mock_bash):
+    cmd = "/bin/bash /tmp/cron-wrapper.sh job-1 cronboard1:ZWNobyBoZWxsbw=="
+
+    assert mod.notifications_enabled(cmd) is True
+
+
+def test_notifications_enabled_with_flag(mock_bash):
+    cmd = "/bin/bash /tmp/cron-wrapper.sh job-1 --no-notify cronboard1:ZWNobyBoZWxsbw=="
+
+    assert mod.notifications_enabled(cmd) is False
+
+
+def test_notifications_enabled_unwrapped_command(mock_bash):
+    assert mod.notifications_enabled("echo hello") is True
+
+
+def test_notifications_enabled_parse_error(mock_bash):
+    assert mod.notifications_enabled("echo 'unterminated") is True


### PR DESCRIPTION
Notifications could only be turned on or off globally. The cron job form now has an Enable/Disable notifications option, which writes a --no-notify flag into that job's wrapped crontab line. The setting travels with the job, so it needs no extra config and nothing to sync for remote servers.

Lines without the flag notify as before, so existing jobs are unaffected, and the global setting still overrides everything. Notifications are sent by the log wrapper, so a job only notifies when logging is enabled for it.

Job lookup now also compares commands without the wrapper, otherwise toggling the flag on an existing job would add a duplicate crontab entry instead of editing the job in place.

## What this changes

Closes #63. Telegram notifications could only be switched on or off globally.
The cron job form now has an Enable/Disable notifications option.

Disabling writes a `--no-notify` flag into the job's wrapped crontab line, so the
setting lives with the job and needs no extra config, no new dependency, and no
syncing for remote servers. A line without the flag notifies as before, so
existing jobs keep working. The global setting still overrides everything, and
notifications require logging since the wrapper is what sends them.

Job lookup now also compares commands without the wrapper, otherwise toggling the
flag on an existing job would add a duplicate crontab entry instead of editing it.

## How I tested this

- Added unit tests for wrapping, unwrapping and reading the flag, plus a modal test
- Ran cron-wrapper.sh directly with a fake curl: a notification is sent only when the
  job fails, the global setting is on, and the job is not opted out
- Checked a job with the flag can still be edited, paused and deleted from the table
- Full test suite passes

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] A human has reviewed the **entire diff** of this PR, every line of code
- [x] A human understands the changes and can explain why this approach is correct
- [x] This PR doesn't have AI-generated boilerplate or co-author lines
- [ ] This PR was authored and submitted by an AI agent without human review
- [ ] I did not answer truthfully to ALL the above checkboxes
