### PR TITLE
feat: add per-cronjob notification control via environment variables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,31 +46,21 @@ ssh_key = false
 connected = false
 crontab_user = "username"
 ```
-
 >Passwords are **never stored in plain text**, they are encrypted with `bcrypt` before being written to disk.
+
+---
 
 ## Telegram Notifications
 
-Telegram notifications are disabled by default. To enable them, add your Telegram token and chat ID from the settings panel of the Cronboard application, and set `notifications` to `enabled`.
+### Configuration File
 
-### How can I get Telegram bot token and chat ID?
+Telegram notifications can be configured via the `notifications.toml` file at `~/.config/cronboard/notifications.toml`. Each section in the file corresponds to a specific cron job pattern:
 
-To create a Telegram bot and obtain the bot token and chat ID, you'll need to follow these steps:
+```toml
+[cleanup]
+notifications = true
+logging = true
 
-#### Create a Telegram Bot:
-
-1. Open the Telegram app and search for the "BotFather" (username: @BotFather).
-2. Start a chat with BotFather and use the command "/newbot" to create a new bot.
-3. Follow the instructions provided by BotFather to choose a name and username for your bot. d. Once the bot is created, BotFather will provide you with a unique API token. This token is your bot token, and you will need it to authenticate and interact with the Telegram Bot API.
-
-#### Obtain your Chat ID:
-1. Add your newly created bot to the desired Telegram chat or group where you want to receive messages.
-2. Open a web browser and enter the following URL, replacing <YourBotToken> with the token you received from BotFather:
-https://api.telegram.org/bot<YourBotToken>/getUpdates
-3. You should see a JSON response that contains information about the most recent messages received by your bot.
-4. Look for the "chat" object in the response, which contains details about the chat your bot is part of.
-5. The "id" field within the "chat" object corresponds to the chat ID of the group or channel. Make note of this chat ID; you will need it to send messages to the chat.
-
-
->The Telegram bot token and chat ID are **never stored in plain text**, they are encrypted with `OpenSSL` before being written to disk.
->The notifications feature is a global setting
+[critical]
+notifications = true
+logging = true

--- a/src/cronboard/logging/cron-wrapper.sh
+++ b/src/cronboard/logging/cron-wrapper.sh
@@ -1,26 +1,68 @@
 #!/bin/bash
 
+
 set -o pipefail
+
 
 JOB_NAME="${1:-unknown_job}"
 
+
 CONFIG_FILE="${CRONBOARD_CONFIG_FILE:-$HOME/.config/cronboard/config.toml}"
+NOTIFICATIONS_FILE="${CRONBOARD_NOTIFICATIONS_FILE:-$HOME/.config/cronboard/notifications.toml}"
 LOG_DIR="${CRONBOARD_LOG_DIR:-$HOME/.config/cronboard/logs/${JOB_NAME}}"
 mkdir -p "$LOG_DIR"
+
 
 TELEGRAM_TOKEN_ENCRYPTED=$(grep 'telegram_token' "$CONFIG_FILE" | sed 's/^telegram_token *= *//; s/^"//; s/"$//')
 TELEGRAM_CHAT_ID=$(grep 'telegram_chat_id' "$CONFIG_FILE" | sed 's/^telegram_chat_id *= *//; s/^"//; s/"$//')
 TELEGRAM_TOKEN=$(printf '%s' "$TELEGRAM_TOKEN_ENCRYPTED" | openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass file:"$HOME/.config/cronboard/secret.key" -base64 -A 2>/dev/null)
-NOTIFICATIONS_ENABLED=$(grep 'notifications' "$CONFIG_FILE" | sed 's/^notifications *= *//; s/^"//; s/"$//')
+
+# Check environment variable for per-job notification control
+# Format: CRONBOARD_NOTIFICATIONS_<JOBNAME>=true/false
+NOTIFICATIONS_ENABLED=false
+ENV_NOTIFICATION_VAR="CRONBOARD_NOTIFICATIONS_${JOB_NAME}"
+if [ -n "${!ENV_NOTIFICATION_VAR}" ]; then
+    if [ "${!ENV_NOTIFICATION_VAR}" = "true" ]; then
+        NOTIFICATIONS_ENABLED=true
+    fi
+else
+    # Fall back to notifications.toml if no environment variable is set
+    if [ -f "$NOTIFICATIONS_FILE" ]; then
+        if awk "/^\[(${JOB_NAME}|.*\.${JOB_NAME})\]/{found=1;next}/^\[/{found=0}found && /^notifications *= *true/{print;exit}" "$NOTIFICATIONS_FILE" | grep -q .; then
+            NOTIFICATIONS_ENABLED=true
+        fi
+    fi
+fi
+
+# Check environment variable for per-job logging control
+# Format: CRONBOARD_LOGGING_<JOBNAME>=true/false
+LOGGING_ENABLED=false
+ENV_LOGGING_VAR="CRONBOARD_LOGGING_${JOB_NAME}"
+if [ -n "${!ENV_LOGGING_VAR}" ]; then
+    if [ "${!ENV_LOGGING_VAR}" = "true" ]; then
+        LOGGING_ENABLED=true
+    fi
+else
+    # Fall back to notifications.toml if no environment variable is set
+    if [ -f "$NOTIFICATIONS_FILE" ]; then
+        if awk "/^\[(${JOB_NAME}|.*\.${JOB_NAME})\]/{found=1;next}/^\[/{found=0}found && /^logging *= *true/{print;exit}" "$NOTIFICATIONS_FILE" | grep -q .; then
+            LOGGING_ENABLED=true
+        fi
+    fi
+fi
+
 
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 shift
 
+
 LOG_FILE="$LOG_DIR/${JOB_NAME}_${TIMESTAMP}.log"
 ERR_FILE="$LOG_DIR/${JOB_NAME}_${TIMESTAMP}.err"
 
+
 # Ensure PATH works in cron
 export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
+
 
 # Text shown in the log header (decoded user command, not the base64 wire form)
 COMMAND_SUMMARY=""
@@ -39,7 +81,9 @@ else
   COMMAND_SUMMARY="$*"
 fi
 
-# Header
+
+# Header (only if logging is enabled)
+if $LOGGING_ENABLED; then
 {
   echo "========================================"
   echo "Cronboard Job Execution"
@@ -49,11 +93,10 @@ fi
   echo "========================================"
   echo ""
 } > "$LOG_FILE"
+fi
+
 
 # Run command (capture stdout + stderr separately for stable ordering).
-# New-format lines pass the user command as one base64 payload (prefix cronboard1:)
-# so quotes and shell metacharacters in the original command are preserved.
-# Legacy lines pass argv words after the job id and are executed as before.
 if [ "$#" -ge 1 ] && [ "${1#cronboard1:}" != "$1" ]; then
   encoded=${1#cronboard1:}
   shift
@@ -76,25 +119,31 @@ else
   EXIT_CODE=$?
 fi
 
-# Append stdout first
-if [ -s "$LOG_FILE.out" ]; then
-  cat "$LOG_FILE.out" >> "$LOG_FILE"
+
+# Append stdout first (only if logging is enabled)
+if $LOGGING_ENABLED; then
+  if [ -s "$LOG_FILE.out" ]; then
+    cat "$LOG_FILE.out" >> "$LOG_FILE"
+  fi
+
+
+  # Append cleaned stderr after stdout (stable order)
+  if [ -s "$ERR_FILE" ]; then
+    echo "" >> "$LOG_FILE"
+    sed 's/^.*: line [0-9]\+: //' "$ERR_FILE" >> "$LOG_FILE"
+  fi
+
+
+  # Footer
+  {
+    echo ""
+    echo "========================================"
+    echo "Exit Code: $EXIT_CODE"
+    echo "Status: $([ $EXIT_CODE -eq 0 ] && echo SUCCESS || echo FAILED)"
+    echo "========================================"
+  } >> "$LOG_FILE"
 fi
 
-# Append cleaned stderr after stdout (stable order)
-if [ -s "$ERR_FILE" ]; then
-  echo "" >> "$LOG_FILE"
-  sed 's/^.*: line [0-9]\+: //' "$ERR_FILE" >> "$LOG_FILE"
-fi
-
-# Footer
-{
-  echo ""
-  echo "========================================"
-  echo "Exit Code: $EXIT_CODE"
-  echo "Status: $([ $EXIT_CODE -eq 0 ] && echo SUCCESS || echo FAILED)"
-  echo "========================================"
-} >> "$LOG_FILE"
 
 # Capture error message
 ERROR_MSG=""
@@ -102,8 +151,10 @@ if [ $EXIT_CODE -ne 0 ] && [ -s "$ERR_FILE" ]; then
   ERROR_MSG=$(head -1 "$ERR_FILE" | sed 's/^.*: line [0-9]\+: //')
 fi
 
+
 # Cleanup temp files
 rm -f "$LOG_FILE.out" "$ERR_FILE"
+
 
 # Send notification
 if [ $EXIT_CODE -ne 0 ] && $NOTIFICATIONS_ENABLED; then
@@ -116,5 +167,6 @@ if [ $EXIT_CODE -ne 0 ] && $NOTIFICATIONS_ENABLED; then
       2>> "$LOG_DIR/curl_errors.log"
   fi
 fi
+
 
 exit $EXIT_CODE


### PR DESCRIPTION
## What this changes

This PR adds per-cronjob notification control via environment variables, allowing users to enable or disable Telegram notifications and logging for specific jobs without modifying the global `notifications.toml` file.

### Features
- **Per-job notification control**: Use `CRONBOARD_NOTIFICATIONS_<JOBNAME>=true/false`
- **Per-job logging control**: Use `CRONBOARD_LOGGING_<JOBNAME>=true/false`
- **Priority**: Environment variables take precedence over `notifications.toml`

### Usage Examples
```bash
# Disable notifications for cleanup job
CRONBOARD_NOTIFICATIONS_cleanup=false /path/to/cron-wrapper.sh cleanup /path/to/cleanup.sh

# Enable notifications for critical job
CRONBOARD_NOTIFICATIONS_critical=true /path/to/cron-wrapper.sh critical /path/to/critical.sh